### PR TITLE
Silence automake warnings.

### DIFF
--- a/xdelta1/xdelta.m4
+++ b/xdelta1/xdelta.m4
@@ -4,7 +4,7 @@
 dnl AM_PATH_XDELTA([MINIMUM-VERSION, [ACTION-IF-FOUND [, ACTION-IF-NOT-FOUND [, MODULES]]]])
 dnl Test for XDELTA, and define XDELTA_CFLAGS and XDELTA_LIBS, if "gmodule" or
 dnl
-AC_DEFUN(AM_PATH_XDELTA,
+AC_DEFUN([AM_PATH_XDELTA],
 [dnl
 dnl Get the cflags and libraries from the xdelta-config script
 dnl


### PR DESCRIPTION
I know this is old, but I have xdelta installed and whenever I run `autoreconf -fi` I get these warnings (With gegl for example). Its rather annoying and it would be nice to silence them for good... :)
```
$  autoreconf -fi
Copying file m4/codeset.m4
Copying file m4/extern-inline.m4
Copying file m4/fcntl-o.m4
Copying file m4/glibc2.m4
Copying file m4/glibc21.m4
Copying file m4/intdiv0.m4
Copying file m4/intl.m4
Copying file m4/intldir.m4
Copying file m4/intmax.m4
Copying file m4/inttypes-pri.m4
Copying file m4/inttypes_h.m4
Copying file m4/lcmessage.m4
Copying file m4/lock.m4
Copying file m4/longlong.m4
Copying file m4/printf-posix.m4
Copying file m4/size_max.m4
Copying file m4/stdint_h.m4
Copying file m4/threadlib.m4
Copying file m4/uintmax_t.m4
Copying file m4/visibility.m4
Copying file m4/wchar_t.m4
Copying file m4/wint_t.m4
Copying file m4/xsize.m4
Copying file po/Makevars.template
/usr/share/aclocal/xdelta.m4:7: warning: underquoted definition of AM_PATH_XDELTA
/usr/share/aclocal/xdelta.m4:7:   run info Automake 'Extending aclocal'
/usr/share/aclocal/xdelta.m4:7:   or see https://www.gnu.org/software/automake/manual/automake.html#Extending-aclocal
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
/usr/share/aclocal/xdelta.m4:7: warning: underquoted definition of AM_PATH_XDELTA
/usr/share/aclocal/xdelta.m4:7:   run info Automake 'Extending aclocal'
/usr/share/aclocal/xdelta.m4:7:   or see https://www.gnu.org/software/automake/manual/automake.html#Extending-aclocal
configure.ac:185: installing './compile'
configure.ac:144: installing './missing'
bin/Makefile.am: installing './depcomp'
```